### PR TITLE
Put quotes around ssl config options

### DIFF
--- a/docs/source/configuration-file-example.rst
+++ b/docs/source/configuration-file-example.rst
@@ -11,5 +11,5 @@ Configuration file example
     port=25
     pid="/tmp/blackhole.io"
     mode="offline"
-    ssl_key=/etc/ssl/private/blackhole.io.key
-    ssl_cert=/etc/ssl/certs/blackhole.io.crt
+    ssl_key="/etc/ssl/private/blackhole.io.key"
+    ssl_cert="/etc/ssl/certs/blackhole.io.crt"


### PR DESCRIPTION
Blackhole raises syntax error without quotes.
