### PR TITLE
Remove exception if not root and port < 1024

### DIFF
--- a/blackhole/config.py
+++ b/blackhole/config.py
@@ -924,9 +924,6 @@ class Config(metaclass=Singleton):
                                  permissions for.
         """
         self._min_max_port(port)
-        if os.getuid() != 0 and port < 1024:
-            msg = "You do not have permission to use port {0}".format(port)
-            raise ConfigException(msg)
         sock = socket.socket(family, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:


### PR DESCRIPTION
This is unnecessary as an exception will be raised in just a few lines ('Could not use port {0}, {1}') if the user doesn't have access. This code prevents non-root users who DO have permissions to listen on low numbered ports from doing so. Such as users with an authbind permission. So I recommend removing it.