### PR TITLE
refactor: add wait_closed in close method

### DIFF
--- a/blackhole/protocols.py
+++ b/blackhole/protocols.py
@@ -149,6 +149,7 @@ class StreamReaderProtocol(asyncio.StreamReaderProtocol):
                 pass
             self._writer.close()
             await self._writer.drain()
+            await self._writer.wait_closed()
         self._connection_closed = True
 
     async def push(self, msg):


### PR DESCRIPTION
This PR add `await self._writer.wait_closed()` to ensure the connection is fully closed, resources are released, and execution only continues after that.
